### PR TITLE
Feature/29 AI 응답 목록 무한 스크롤 기능 추가

### DIFF
--- a/src/components/ai/StoredAIResponseList.tsx
+++ b/src/components/ai/StoredAIResponseList.tsx
@@ -1,29 +1,39 @@
 'use client';
 
-import { useOpenAIStore } from '@/store/openaiStore';
+import useStoredAIResponseList from '@/hooks/ai/useStoredAIResponseList';
+import useInfiniteScroll from '@/hooks/utils/useInfiniteScroll';
 import ReactMarkdown from 'react-markdown';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 
 function StoredAIResponseList() {
-  const { storedAIResponse } = useOpenAIStore();
+  const { data, fetchNextPage, hasNextPage, isLoading } =
+    useStoredAIResponseList();
+  const observerTarget = useInfiniteScroll({
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+  });
 
   return (
     <div
       className="border-card-background grid grid-cols-1 gap-4 rounded-xl border
 								bg-background p-4 text-card-foreground shadow md:grid-cols-2 lg:grid-cols-3"
     >
-      {storedAIResponse.map((response, index) => (
-        <Card key={index} className="bg-secondary">
-          <CardHeader>
-            <CardTitle className="text-lg font-bold">
-              {response.title}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ReactMarkdown>{response.content}</ReactMarkdown>
-          </CardContent>
-        </Card>
-      ))}
+      {data.map(
+        (response: { title: string; content: string }, index: number) => (
+          <Card key={index} className="bg-secondary">
+            <CardHeader>
+              <CardTitle className="text-lg font-bold">
+                {response.title}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ReactMarkdown>{response.content}</ReactMarkdown>
+            </CardContent>
+          </Card>
+        )
+      )}
+      <div ref={observerTarget} className="h-4 w-full" />
     </div>
   );
 }

--- a/src/hooks/ai/useStoredAIResponseList.ts
+++ b/src/hooks/ai/useStoredAIResponseList.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useOpenAIStore } from '@/store/openaiStore';
+import { useEffect, useState } from 'react';
+
+const PAGE_SIZE = 10;
+
+export default function useStoredAIResponseList() {
+  const { storedAIResponse } = useOpenAIStore();
+  const [currentPage, setCurrentPage] = useState(0);
+  const [data, setData] = useState(storedAIResponse.slice(0, PAGE_SIZE));
+  const [hasNextPage, setHasNextPage] = useState(
+    storedAIResponse.length > PAGE_SIZE
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchNextPage = () => {
+    if (!hasNextPage || isLoading) return;
+    setIsLoading(true);
+    const nextPage = currentPage + 1;
+    const start = nextPage * PAGE_SIZE;
+    const end = start + PAGE_SIZE;
+    const nextData = storedAIResponse.slice(start, end);
+    setData((prevData) => [...prevData, ...nextData]);
+    setCurrentPage(nextPage);
+    setHasNextPage(end < storedAIResponse.length);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    setData(storedAIResponse.slice(0, PAGE_SIZE));
+    setCurrentPage(0);
+    setHasNextPage(storedAIResponse.length > PAGE_SIZE);
+  }, [storedAIResponse]);
+
+  return { data, fetchNextPage, hasNextPage, isLoading };
+}

--- a/src/hooks/utils/useInfiniteScroll.ts
+++ b/src/hooks/utils/useInfiniteScroll.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+type useInfiniteScrollProps = {
+  fetchNextPage: () => void;
+  hasNextPage: boolean;
+  isLoading: boolean;
+};
+
+export default function useInfiniteScroll({
+  fetchNextPage,
+  hasNextPage,
+  isLoading,
+}: useInfiniteScrollProps) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!hasNextPage || isLoading) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          fetchNextPage();
+        }
+      },
+      {
+        threshold: 1.0,
+      }
+    );
+
+    const target = targetRef.current;
+    if (target) observer.observe(target);
+
+    return () => {
+      if (target) observer.unobserve(target);
+    };
+  }, [fetchNextPage, hasNextPage, isLoading]);
+
+  return targetRef;
+}


### PR DESCRIPTION
### 개요 (Summary)
`/dashboard/ai` 페이지에 무한 스크롤 기능을 추가하여 사용자 경험을 개선했습니다.
모든 데이터를 한 번에 렌더링하던 방식에서, 스크롤 시 추가 데이터를 불러오는 방식으로 변경하였습니다.
- `StoredAIResponseList` 컴포넌트에서 `useStoredAIResponseList` 훅을 사용하여 AI 응답 목록을 페이지네이션 처리
- `useInfiniteScroll` 훅을 추가하여 스크롤 시 다음 페이지 데이터를 불러오는 기능 구현

### 변경 사항 (Changes)

1. **주요 기능/로직**:
   - `useStoredAIResponseList` 훅: 페이지네이션을 통해 데이터를 관리하고, `fetchNextPage` 함수를 통해 다음 페이지 데이터를 로드합니다.
   - `useInfiniteScroll` 훅: `IntersectionObserver`를 사용하여 스크롤 시 다음 페이지 데이터를 불러옵니다.

2. **버그 수정**:
   - 없음

3. **기타**:
   - `IntersectionObserver`를 활용하여 성능 최적화

### 스크린샷(선택)
![Mar-26-2025 12-03-54](https://github.com/user-attachments/assets/9fab46e5-12e5-4547-84dd-eb48f3c852d4)



### 관련 이슈

- Closes #29

### 기타 (Additional context)

- 현재 데이터는 로컬스토리지를 사용하고 있지만, 실제 API 기반으로 전환되더라도 구조는 동일하게 유지가 가능합니다.
- `IntersectionObserver`는 `unobserve` 및 cleanup 처리를 해야 메모리 누수를 방지할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 무한 스크롤 기능이 추가되어, 스크롤 시 추가 응답 데이터가 자동으로 로드됩니다.
  
- **리팩토링**
  - AI 응답 목록의 데이터 처리 및 렌더링 로직이 개선되어, 페이지네이션과 로딩 상태 관리가 한층 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->